### PR TITLE
fix(a11y): Melhora semântica e contraste de cores

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -886,3 +886,8 @@ button:disabled {
 @media (min-width: 768px) {
   .project-details-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: stretch; }
 }
+
+[data-theme="dark"] .footer a {
+  color: var(--color-primary-light); 
+  text-decoration: underline; 
+}

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   </header>
 
   <!-- ======================== HERO SECTION ======================== -->
-  <main id="inicio" class="bgimage" data-testid="hero-section" role="region" aria-label="Banner ilustrado com retrato animado de Joelma de Oliveira Prestes Ferreira" tabindex="-1">
+  <main id="inicio" class="bgimage" data-testid="hero-section" aria-label="Banner ilustrado com retrato animado de Joelma de Oliveira Prestes Ferreira" tabindex="-1">
     <div class="text-overlay" data-testid="hero-content" role="group" aria-labelledby="hero-nome" aria-describedby="hero-profissao">
       <h1 id="hero-nome" class="heroTitulo" data-testid="hero-title" data-translate-key="hero_title">Joelma de O. Prestes Ferreira</h1>
       <p id="hero-profissao" class="heroDesc" data-testid="hero-description" data-translate-key="hero_description">Líder de Engenharia de Qualidade de Software</p>


### PR DESCRIPTION
- Remove `role="region"` redundante da tag `<main>` para utilizar a semântica nativa de landmark principal.
- Aumenta o contraste da cor dos links no rodapé no modo escuro para atender aos requisitos WCAG AA.